### PR TITLE
Change OpenSSL require for linux compatibility

### DIFF
--- a/lib/signature.rb
+++ b/lib/signature.rb
@@ -1,5 +1,5 @@
 require "base64"
-require "openSSL"
+require "opessl"
 
 
 class Signature


### PR DESCRIPTION
change OpenSSL require from 'openSSL' to 'openssl' for linux compatibility, it won't load the reference in the current state