### PR TITLE
Fixes up namespaces for gem files

### DIFF
--- a/lib/ecdsa.rb
+++ b/lib/ecdsa.rb
@@ -1,28 +1,28 @@
 require 'digest'
 require 'openssl'
-require 'signature'
+require_relative 'signature'
 
 
-module Ecdsa
+module EllipticCurve
+    module Ecdsa
+        def self.sign(message, privateKey, hashfunc=nil)
+            if hashfunc.nil?
+                message = Digest::SHA256.digest(message)
+            else
+                message = hashfunc(message)
+            end
 
-    def self.sign(message, privateKey, hashfunc=nil)
-        if hashfunc.nil?
-            message = Digest::SHA256.digest(message)
-        else
-            message = hashfunc(message)
+            signature = privateKey.openSslPrivateKey.dsa_sign_asn1(message)
+            return Signature.new(signature)
         end
 
-        signature = privateKey.openSslPrivateKey.dsa_sign_asn1(message)
-        return Signature.new(signature)
-    end
-
-    def self.verify(message, signature, publicKey, hashfunc=nil)
-        if hashfunc.nil?
-            message = Digest::SHA256.digest(message)
-        else
-            message = hashfunc(message)
+        def self.verify(message, signature, publicKey, hashfunc=nil)
+            if hashfunc.nil?
+                message = Digest::SHA256.digest(message)
+            else
+                message = hashfunc(message)
+            end
+            return publicKey.openSslPublicKey.dsa_verify_asn1(message, signature.toDer())
         end
-        return publicKey.openSslPublicKey.dsa_verify_asn1(message, signature.toDer())
     end
-
 end

--- a/lib/privatekey.rb
+++ b/lib/privatekey.rb
@@ -2,48 +2,49 @@ require "openssl"
 require "base64"
 require_relative "publickey"
 
+module EllipticCurve
+    class PrivateKey
 
-class PrivateKey
-
-    def initialize(curve="secp256k1", openSslKey=nil)
-        if openSslKey.nil?
-            @openSslPrivateKey = OpenSSL::PKey::EC.new(curve)
-            @openSslPrivateKey.generate_key
-        else
-            @openSslPrivateKey = openSslKey
+        def initialize(curve="secp256k1", openSslKey=nil)
+            if openSslKey.nil?
+                @openSslPrivateKey = OpenSSL::PKey::EC.new(curve)
+                @openSslPrivateKey.generate_key
+            else
+                @openSslPrivateKey = openSslKey
+            end
         end
+
+        attr_reader :openSslPrivateKey
+
+        def publicKey
+            dupKey = OpenSSL::PKey::EC.new(@openSslPrivateKey.to_der())
+            dupKey.private_key = nil
+            return PublicKey.new(dupKey)
+        end
+
+        def toString
+            return Base64.encode64(self.toDer())
+        end
+
+        def toDer
+            return @openSslPrivateKey.to_der()
+        end
+
+        def toPem
+            return @openSslPrivateKey.to_pem()
+        end
+
+        def self.fromPem(string)
+            return PrivateKey.new(nil, OpenSSL::PKey::EC.new(string))
+        end
+
+        def self.fromDer(string)
+            return PrivateKey.new(nil, OpenSSL::PKey::EC.new(string))
+        end
+
+        def self.fromString(string)
+            return PrivateKey.new(nil, OpenSSL::PKey::EC.new(Base64.decode64(string)))
+        end
+
     end
-
-    attr_reader :openSslPrivateKey
-
-    def publicKey
-        dupKey = OpenSSL::PKey::EC.new(@openSslPrivateKey.to_der())
-        dupKey.private_key = nil
-        return PublicKey.new(dupKey)
-    end
-
-    def toString
-        return Base64.encode64(self.toDer())
-    end
-
-    def toDer
-        return @openSslPrivateKey.to_der()
-    end
-
-    def toPem
-        return @openSslPrivateKey.to_pem()
-    end
-
-    def self.fromPem(string)
-        return PrivateKey.new(nil, OpenSSL::PKey::EC.new(string))
-    end
-
-    def self.fromDer(string)
-        return PrivateKey.new(nil, OpenSSL::PKey::EC.new(string))
-    end
-
-    def self.fromString(string)
-        return PrivateKey.new(nil, OpenSSL::PKey::EC.new(Base64.decode64(string)))
-    end
-
 end

--- a/lib/publickey.rb
+++ b/lib/publickey.rb
@@ -1,33 +1,33 @@
-class PublicKey
+module EllipticCurve
+    class PublicKey
+        def initialize(openSslPublicKey)
+            @openSslPublicKey = openSslPublicKey
+        end
 
-    def initialize(openSslPublicKey)
-        @openSslPublicKey = openSslPublicKey
+        attr_reader :openSslPublicKey
+
+        def toString
+            return Base64.encode64(self.toDer())
+        end
+
+        def toDer
+            @openSslPublicKey.to_der()
+        end
+
+        def toPem
+            @openSslPublicKey.to_pem()
+        end
+
+        def self.fromPem(string)
+            return PublicKey.new(OpenSSL::PKey::EC.new(string))
+        end
+
+        def self.fromDer(string)
+            return PublicKey.new(OpenSSL::PKey::EC.new(string))
+        end
+
+        def self.fromString(string)
+            return PublicKey.new(OpenSSL::PKey::EC.new(Base64.decode64(string)))
+        end
     end
-
-    attr_reader :openSslPublicKey
-
-    def toString
-        return Base64.encode64(self.toDer())
-    end
-
-    def toDer
-        @openSslPublicKey.to_der()
-    end
-
-    def toPem
-        @openSslPublicKey.to_pem()
-    end
-
-    def self.fromPem(string)
-        return PublicKey.new(OpenSSL::PKey::EC.new(string))
-    end
-
-    def self.fromDer(string)
-        return PublicKey.new(OpenSSL::PKey::EC.new(string))
-    end
-
-    def self.fromString(string)
-        return PublicKey.new(OpenSSL::PKey::EC.new(Base64.decode64(string)))
-    end
-
 end

--- a/lib/signature.rb
+++ b/lib/signature.rb
@@ -1,32 +1,32 @@
 require "base64"
 require "openssl"
 
+module EllipticCurve
+    class Signature
+        def initialize(der)
+            @der = der
+            decoded = OpenSSL::ASN1.decode(der).value
+            @r = decoded[0].value
+            @s = decoded[1].value
+        end
 
-class Signature
+        attr_reader :r, :s
 
-    def initialize(der)
-        @der = der
-        decoded = OpenSSL::ASN1.decode(der).value
-        @r = decoded[0].value
-        @s = decoded[1].value
+        def toDer
+            return @der
+        end
+
+        def toBase64
+            Base64.encode64(self.toDer()).gsub("\n", "")
+        end
+
+        def self.fromDer(string)
+            return Signature.new(string)
+        end
+
+        def self.fromBase64(string)
+            self.fromDer(Base64.decode64(string))
+        end
+
     end
-
-    attr_reader :r, :s
-
-    def toDer
-        return @der
-    end
-
-    def toBase64
-        Base64.encode64(self.toDer()).gsub("\n", "")
-    end
-
-    def self.fromDer(string)
-        return Signature.new(string)
-    end
-
-    def self.fromBase64(string)
-        self.fromDer(Base64.decode64(string))
-    end
-
 end

--- a/lib/starkbank-ecdsa.rb
+++ b/lib/starkbank-ecdsa.rb
@@ -6,14 +6,4 @@ require_relative "utils/file"
 
 
 module EllipticCurve
-
-    Signature = Signature
-    PublicKey = PublicKey
-    PrivateKey = PrivateKey
-    Ecdsa = Ecdsa
-
-    module Utils
-        File = File
-    end
-
 end

--- a/lib/utils/file.rb
+++ b/lib/utils/file.rb
@@ -1,10 +1,12 @@
-class File
-
-    def self.read(path, encoding="ASCII")
-        file = File.open(path, :encoding => encoding.upcase)
-        content = file.read
-        file.close
-        return content
+module EllipticCurve
+    module Utils
+        class File
+            def self.read(path, encoding="ASCII")
+                file = ::File.open(path, :encoding => encoding.upcase)
+                content = file.read
+                file.close
+                return content
+            end
+        end
     end
-
 end

--- a/test/test.rb
+++ b/test/test.rb
@@ -1,4 +1,4 @@
-require 'starkbank-ecdsa'
+require_relative '../lib/starkbank-ecdsa'
 
 $success = 0
 $failure = 0


### PR DESCRIPTION
Embedding the classes within the `EllipticCurve` module saves you having to assign them in the `starbank-ecdsa` file. It also stops clobbering the Ruby standard lib `File#read` method, fixing the issue reported in #4.